### PR TITLE
api/v1: support image creation

### DIFF
--- a/images.go
+++ b/images.go
@@ -27,6 +27,19 @@ type Image struct {
 	LicenceName       string `json:"licence_name"`
 }
 
+type ImageOptions struct {
+	Arch              string `json:"arch"`
+	CompatibilityMode bool   `json:"compatibility_mode"`
+	Description       string `json:"description"`
+	MinRam            int    `json:"min_ram"`
+	Name              string `json:"name"`
+	Public            bool   `json:"public"`
+	Username          string `json:"username"`
+	Server            string `json:"server,omitempty"`
+	Volume            string `json:"volume,omitempty"`
+	HTTPURL           string `json:"http_url,omitempty"`
+}
+
 // Images retrieves a list of all images
 func (c *Client) Images() ([]Image, error) {
 	var images []Image
@@ -54,4 +67,14 @@ func (c *Client) DestroyImage(identifier string) error {
 		return err
 	}
 	return nil
+}
+
+// CreateImage issues a request to create an image
+func (c *Client) CreateImage(newImage *ImageOptions) (*Image, error) {
+	image := new(Image)
+	if _, err := c.MakeAPIRequest("POST", "/1.0/images", newImage, &image); err != nil {
+		return nil, err
+	}
+
+	return image, nil
 }


### PR DESCRIPTION
Hi,

In this PR we add the support for image creation in the V1 API.

Locally tested with:
```go
image, err := client.CreateImage(&brightbox.ImageOptions{
	Arch:              "x86_64",
	CompatibilityMode: true,
	Description:       "test  flatcar",
	MinRam:            2048,
	Name:              "test-flatcar",
	Public:            false,
	Username:          "core",
	HTTPURL:           "https://.../flatcar_production_openstack_image.img",
})
if err != nil {
	fmt.Println(err)
	return
}

fmt.Println(image)
```

NOTE: I don't know what's the current status of the V1 API as https://api.gb1.brightbox.com/ only proposes `V1` ? 