### PR TITLE
v2/images: remove source and add URL parameter

### DIFF
--- a/v2/images.go
+++ b/v2/images.go
@@ -48,10 +48,10 @@ type ImageOptions struct {
 	Description       *string          `json:"description,omitempty"`
 	MinRAM            *uint            `json:"min_ram,omitempty"`
 	Server            string           `json:"server,omitempty"`
-	Source            string           `json:"source,omitempty"`
 	Volume            string           `json:"volume,omitempty"`
 	Arch              arch.Enum        `json:"arch,omitempty"`
 	Status            imagestatus.Enum `json:"status,omitempty"`
 	Public            *bool            `json:"public,omitempty"`
 	CompatibilityMode *bool            `json:"compatibility_mode,omitempty"`
+	URL               string           `json:"http_url,omitempty"`
 }

--- a/v2/images_test.go
+++ b/v2/images_test.go
@@ -8,8 +8,8 @@ import (
 )
 
 func TestCreateImageWithSource(t *testing.T) {
-	pg := "ubuntu-lucid-daily-i64-server-20110509"
-	newResource := ImageOptions{Source: pg}
+	pg := "https://api.gb1.brightbox.com/1.0/images/img-3ikco"
+	newResource := ImageOptions{URL: pg}
 	instance := testModify(
 		t,
 		(*Client).CreateImage,
@@ -17,8 +17,8 @@ func TestCreateImageWithSource(t *testing.T) {
 		"image",
 		"POST",
 		"images",
-		`{"source":"ubuntu-lucid-daily-i64-server-20110509"}`,
+		`{"http_url":"https://api.gb1.brightbox.com/1.0/images/img-3ikco"}`,
 	)
-	assert.Equal(t, instance.Source, pg)
+	assert.Equal(t, instance.URL, pg)
 	assert.Equal(t, instance.Arch, arch.X86_64)
 }


### PR DESCRIPTION
The `source` option was tied to the FTP based workflow which is no longer supported. Thus the option would trigger an unresolvable error for the SDK user.

(From: https://github.com/brightbox/brightbox-cli/commit/10cb209ffbca22a710017063aa77c678395d066e)

---

Locally tested with:
```go
img, err := client.CreateImage(ctx, brightbox.ImageOptions{
	Arch:              arch.X86_64,
	Name:              &name,
	Username:          &username,
	MinRAM:            &ram,
	URL:               "https://...flatcar_production_openstack_image.img",
	Public:            &public,
	CompatibilityMode: &compatibilityMode,
})
if err != nil {
	log.Fatal(err)
}

fmt.Println(img)
```