### PR TITLE
v2/servers: add docstring for userdata

### DIFF
--- a/v2/servers.go
+++ b/v2/servers.go
@@ -51,6 +51,7 @@ type ServerConsole struct {
 
 // ServerOptions is used in conjunction with CreateServer and UpdateServer to
 // create and update servers.
+// UserData needs to be base64 encoded.
 type ServerOptions struct {
 	ID                 string        `json:"-"`
 	Image              *string       `json:"image,omitempty"`


### PR DESCRIPTION
Hi, 

I think that can be helpful to mention that the UserData, used when creating a new server, has to be bas64 encoded. (See also: https://github.com/brightbox/terraform-provider-brightbox/blob/fd1242006d8e4582cbb617dee6c7cbffd8b468ba/brightbox/resource_brightbox_server.go#L278) 